### PR TITLE
Enable dual-input modality handling

### DIFF
--- a/ultralytics/nn/modules/block.py
+++ b/ultralytics/nn/modules/block.py
@@ -1420,31 +1420,25 @@ class IdentityInput(nn.Module):
 
 
 class ModalitySelector(nn.Module):
-    """
-    ModalitySelector 模块：用于从双模态输入（例如 RGB+IR 图像）中选择其中一个模态通道作为输出。
-    
-    输入格式要求：
-    - 输入张量 x 的形状为 (B, C, H, W)，其中 C 通道数为 6（假设 RGB+IR 各 3 通道）
-    - 默认 x[:, :3, :, :] 是 RGB，x[:, 3:, :, :] 是 IR
+    """从双模态输入中选择其中一个模态。"""
 
-    参数：
-    - out (int): 指定输出哪种模态图像
-        - 1 表示输出 RGB（默认值）
-        - 2 表示输出 IR
-    """
-    def __init__(self, out=1):
+    def __init__(self, out=1, split=None):
+        """Args:
+            out (int): 1 表示选择第一种模态，2 表示选择第二种模态。
+            split (int, optional): 指定通道切分位置，默认为输入通道数的一半。
+        """
         super().__init__()
-        self.out = out  # 控制输出哪个模态通道
+        self.out = out
+        self.split = split
 
     def forward(self, x):
-        # 将输入张量在通道维拆分为两个子张量
-        # x1 是 RGB 图像部分，取前3个通道
-        x1, x2 = x[:, :3, :, :], x[:, 3:, :, :]  # x1: RGB, x2: IR
-
-        # 根据设置的 self.out 选择输出哪个模态图像
-        if self.out == 1:
-            x = x1  # 输出 RGB 图像
+        """支持 tensor 或 [modal1, modal2] 形式的输入。"""
+        if isinstance(x, (list, tuple)):
+            if len(x) != 2:
+                raise ValueError("ModalitySelector expects 2 modalities")
+            x1, x2 = x
         else:
-            x = x2  # 输出 IR 图像
+            c = self.split or x.shape[1] // 2
+            x1, x2 = x[:, :c, ...], x[:, c:, ...]
 
-        return x  # 返回选择的单一模态图像
+        return x1 if self.out == 1 else x2

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -96,6 +96,14 @@ from ultralytics.utils.torch_utils import (
 class BaseModel(nn.Module):
     """The BaseModel class serves as a base class for all the models in the Ultralytics YOLO family."""
 
+    @staticmethod
+    def _split_modalities(x):
+        """If input is multi-modal tensor, split into a list of two tensors."""
+        if isinstance(x, torch.Tensor) and x.ndim == 4 and x.shape[1] > 3:
+            c = x.shape[1] // 2
+            return [x[:, :c, ...], x[:, c:, ...]]
+        return x
+
     def forward(self, x, *args, **kwargs):
         """
         Perform forward pass of the model for either training or inference.
@@ -145,6 +153,7 @@ class BaseModel(nn.Module):
         Returns:
             (torch.Tensor): The last output of the model.
         """
+        x = self._split_modalities(x)
         y, dt, embeddings = [], [], []  # outputs
         for m in self.model:
             if m.f != -1:  # if not from previous layer
@@ -292,7 +301,8 @@ class BaseModel(nn.Module):
         if getattr(self, "criterion", None) is None:
             self.criterion = self.init_criterion()
 
-        preds = self.forward(batch["img"]) if preds is None else preds
+        img = self._split_modalities(batch["img"])
+        preds = self.forward(img) if preds is None else preds
         return self.criterion(preds, batch)
 
     def init_criterion(self):
@@ -529,15 +539,20 @@ class RTDETRDetectionModel(DetectionModel):
         if not hasattr(self, "criterion"):
             self.criterion = self.init_criterion()
 
-        img = batch["img"]
+        img = self._split_modalities(batch["img"])
+        if isinstance(img, (list, tuple)):
+            bs = img[0].shape[0]
+            device = img[0].device
+        else:
+            bs = len(img)
+            device = img.device
         # NOTE: preprocess gt_bbox and gt_labels to list.
-        bs = len(img)
         batch_idx = batch["batch_idx"]
         gt_groups = [(batch_idx == i).sum().item() for i in range(bs)]
         targets = {
-            "cls": batch["cls"].to(img.device, dtype=torch.long).view(-1),
-            "bboxes": batch["bboxes"].to(device=img.device),
-            "batch_idx": batch_idx.to(img.device, dtype=torch.long).view(-1),
+            "cls": batch["cls"].to(device, dtype=torch.long).view(-1),
+            "bboxes": batch["bboxes"].to(device=device),
+            "batch_idx": batch_idx.to(device, dtype=torch.long).view(-1),
             "gt_groups": gt_groups,
         }
 
@@ -557,7 +572,7 @@ class RTDETRDetectionModel(DetectionModel):
         )
         # NOTE: There are like 12 losses in RTDETR, backward with all losses but only show the main three losses.
         return sum(loss.values()), torch.as_tensor(
-            [loss[k].detach() for k in ["loss_giou", "loss_class", "loss_bbox"]], device=img.device
+            [loss[k].detach() for k in ["loss_giou", "loss_class", "loss_bbox"]], device=device
         )
 
     def predict(self, x, profile=False, visualize=False, batch=None, augment=False, embed=None):
@@ -679,7 +694,8 @@ class WorldModel(DetectionModel):
             self.criterion = self.init_criterion()
 
         if preds is None:
-            preds = self.forward(batch["img"], txt_feats=batch["txt_feats"])
+            img = self._split_modalities(batch["img"])
+            preds = self.forward(img, txt_feats=batch["txt_feats"])
         return self.criterion(preds, batch)
 
 


### PR DESCRIPTION
## Summary
- allow `ModalitySelector` to accept [modal1, modal2] input or split tensor inputs
- split multi-modal tensors before forward passes
- update loss functions to work with split modality inputs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68467d449c40832c85597fe386cfa2b2